### PR TITLE
A set of very simple fixes, including fixing the colon issue that @endrawes0 identified

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ps. I will add more detail here later. I just want to get some bare bones instru
 6. Install mocha. ` > node install --save mocha `
 7. Install chai. ` > node install --save chai `
 8. Install moment. ` > node install --save moment `
-9. Install merge. ` > node install --save merge `
+9. Install underscore. ` > node install --save underscore `
 
 ## Start Chesster
 1. Generate a bot token in your Slack Team's Services and Customization.

--- a/chesster.js
+++ b/chesster.js
@@ -1263,7 +1263,6 @@ controller.on('ambient', function(bot, message) {
                 scheduling_reply_cant_schedule_others(bot, message);
                 return;
             }
-            console.log(message);
             results.white = white.name;
             results.black = black.name;
             spreadsheets.update_schedule(

--- a/spreadsheets.js
+++ b/spreadsheets.js
@@ -67,7 +67,7 @@ PairingError.prototype = new Error();
 //         before the round end that we want to warn people about.
 function parse_scheduling(input_string, options) {
     // Do some basic preprocessing
-    input_string = input_string.replace(/[@\.,\(\)\<\>]/g, ' ');
+    input_string = input_string.replace(/[:@\.,\(\)\<\>]/g, ' ');
 
     var parts = input_string.split(" ");
 

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -344,6 +344,14 @@ describe('scheduling', function() {
                     date: "2016-04-15T08:00:00+00:00"
                 }
             );
+            test_parse_scheduling(
+                "<@U0DJTJ15W>: vs <@U0YUPPF4H> 04/16/16 00:00 GMT",
+                {
+                    white: "U0DJTJ15W",
+                    black: "U0YUPPF4H",
+                    date: "2016-04-16T00:00:00+00:00"
+                }
+            );
         });
         it("Test lonewolf-scheduling messages that are out of bounds", function() {
             var options = {

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -347,15 +347,13 @@ describe('scheduling', function() {
         });
         it("Test lonewolf-scheduling messages that are out of bounds", function() {
             var options = {
-                reference_date: moment.utc("2016-04-15"),
-                pairing_offset_hours: 1,
-                game_max_length_hours: 3
+                "extrema": {
+                    reference_date: moment.utc("2016-04-15"),
+                    "iso_weekday": 1,
+                    "hour": 22,
+                    "minute": 0,
+                }
             };
-            function test_parse_scheduling(string, expected)  {
-                assert.equal(results.date.format(), expected.date);
-                assert.equal(results.white, expected.white);
-                assert.equal(results.black, expected.black);
-            }
             try {
                 var results = spreadsheets.parse_scheduling(
                     "@autotelic v @explodingllama 4/19 @ 0900 GMT",
@@ -372,8 +370,8 @@ describe('scheduling', function() {
         });
         it("Test lonewolf-scheduling messages that are out of bounds", function() {
             var options = {
-                "reference_date": moment.utc("2016-04-15"),
                 "extrema": {
+                    "reference_date": moment.utc("2016-04-15"),
                     "iso_weekday": 1,
                     "hour": 22,
                     "minute": 0,
@@ -401,8 +399,8 @@ describe('scheduling', function() {
         });
         it("Test lonewolf-scheduling messages that are in the warning time-period", function() {
             var options = {
-                "reference_date": moment.utc("2016-04-15"),
                 "extrema": {
+                    "reference_date": moment.utc("2016-04-15"),
                     "iso_weekday": 1,
                     "hour": 22,
                     "minute": 0,


### PR DESCRIPTION
1. Fixing the tests to run outside of that round (properly using the extrema.reference_date).
2. Removing an unused test method.
3. Fixing the list of dependencies in the README.md
4. Fixing the parsing of dates that had the colon in them.