### PR TITLE
Fixing two new formats when people include the white/black information.

### DIFF
--- a/spreadsheets.js
+++ b/spreadsheets.js
@@ -44,9 +44,9 @@ var WORDS_TO_IGNORE = [
     "thurs",
     "fri",
     "sat",
-
-    // TODO: yes, this is oddly specific - but unless he changes his username ....
-    "steveharwell"
+    "white",
+    "black",
+    "pieces"
 ];
 
 // A scheduling error (as opposed to other errors)

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -64,6 +64,7 @@ describe('scheduling', function() {
                 assert.equal(results.date.format(), expected.date);
                 assert.equal(results.white, expected.white);
                 assert.equal(results.black, expected.black);
+                assert.equal(results.black, expected.black);
             }
             test_parse_scheduling(
                 "@autotelic v @explodingllama 4/16 @ 0900 GMT", {
@@ -249,14 +250,6 @@ describe('scheduling', function() {
                 }
             );
             test_parse_scheduling(
-                "@steveharwell (greentiger) v @harrison2 Apr 15 at 1500 GMT",
-                {
-                    white: "greentiger",
-                    black: "harrison2",
-                    date: "2016-04-15T15:00:00+00:00"
-                }
-            );
-            test_parse_scheduling(
                 "@jyr vs @droodjerky  15/04 at 17:00 GMT",
                 {
                     white: "jyr",
@@ -350,6 +343,14 @@ describe('scheduling', function() {
                     white: "U0DJTJ15W",
                     black: "U0YUPPF4H",
                     date: "2016-04-16T00:00:00+00:00"
+                }
+            );
+            test_parse_scheduling(
+                "<@U0DJTJ15W> (white pieces) vs <@U0YUPPF4H> (Black pieces) Saturday, 4/17 @20:00 GMT",
+                {
+                    white: "U0DJTJ15W",
+                    black: "U0YUPPF4H",
+                    date: "2016-04-17T20:00:00+00:00"
                 }
             );
         });

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -64,7 +64,6 @@ describe('scheduling', function() {
                 assert.equal(results.date.format(), expected.date);
                 assert.equal(results.white, expected.white);
                 assert.equal(results.black, expected.black);
-                assert.equal(results.black, expected.black);
             }
             test_parse_scheduling(
                 "@autotelic v @explodingllama 4/16 @ 0900 GMT", {


### PR DESCRIPTION
Fixes this: @player1 (white) v @player2 (black) mm/dd @ HH:MM

Also remove the steveharwell hack as it's no longer necessary.