### PR TITLE
Fixing  few date parsing issues - also making it run faster

### DIFF
--- a/spreadsheets.js
+++ b/spreadsheets.js
@@ -65,7 +65,8 @@ var BASE_TIME_FORMATS = [
     "HHmm",
     "Hmm",
     "HH-mm",
-    "H-mm"
+    "H-mm",
+    "HH"
 ];
 var DATE_FORMATS = [
 ];
@@ -208,6 +209,7 @@ function get_possible_date_strings(date_string, extrema) {
     month = now.format("MM");
     date_strings.slice().forEach(function(date_string) {
         date_strings.push("" + year + "-" + date_string);
+        date_strings.push(date_string + "-" + year);
     });
     return date_strings;
 }

--- a/spreadsheets.js
+++ b/spreadsheets.js
@@ -10,6 +10,8 @@ var EXTREMA_DEFAULTS = {
     'warning_hours': 1,
 };
 var BASE_DATE_FORMATS = [
+    "YYYY-MM-DD MM DD",
+    "YYYY-MM DD",
     "YYYY-MM-DD",
     "YYYY-MM-D",
     "YYYY-M-DD",
@@ -42,14 +44,6 @@ var BASE_DATE_FORMATS = [
     "D-MM-YY",
     "DD-M-YY",
     "D-M-YY",
-    "YYYY-MMMM Do",
-    "YY-MMMM Do",
-    "MMMM Do YYYY",
-    "MMMM Do YY",
-    "YYYY-Do MMMM",
-    "YY-Do MMMM",
-    "Do MMMM YYYY",
-    "Do MMMM YY",
     "YYYY-MMMM DD",
     "YY-MMMM DD",
     "MMMM DD YYYY",
@@ -70,20 +64,15 @@ var BASE_DATE_FORMATS = [
 var BASE_TIME_FORMATS = [
     "HHmm",
     "Hmm",
-    "Hm",
     "HH-mm",
-    "H-mm",
-    "H-m"
+    "H-mm"
 ];
 var DATE_FORMATS = [
 ];
 BASE_DATE_FORMATS.forEach(function(date_format) {
     BASE_TIME_FORMATS.forEach(function(time_format) {
-        var date_format2 = date_format.replace(/[-]/g, '');
         DATE_FORMATS.push(date_format + " " + time_format);
         DATE_FORMATS.push(time_format + " " + date_format);
-        DATE_FORMATS.push(date_format2 + " " + time_format);
-        DATE_FORMATS.push(time_format + " " + date_format2);
     });
 });
 var WORDS_TO_IGNORE = [
@@ -102,22 +91,6 @@ var WORDS_TO_IGNORE = [
     "v",
     "vs",
     "versus",
-    "sunday",
-    "monday",
-    "tuesday",
-    "wednesday",
-    "thursday",
-    "friday",
-    "saturday",
-    "sun",
-    "mon",
-    "tues",
-    "wed",
-    "thu",
-    "thur",
-    "thurs",
-    "fri",
-    "sat",
     "white",
     "black",
     "pieces"
@@ -153,7 +126,7 @@ function get_tokens_scheduling(input_string){
     input_string = input_string.replace(/[<\>]/g, '');
 
     var parts = _.map(input_string.split(" "), function(item) {
-        // Remove . and / and : and - from the beginning and end of the string
+        // Remove . and / and : and - from the beginning and end of the word
         item = item.replace(/^[:\.\/-]/g, '');
         item = item.replace(/[:\.\/-]$/g, '');
 
@@ -164,6 +137,81 @@ function get_tokens_scheduling(input_string){
         return WORDS_TO_IGNORE.indexOf(i.toLowerCase()) == -1;
     });
     return parts;
+}
+
+// Take the string they posted and turn it into a set of possible date
+// strings by doing things like:
+//
+// Unifying the punctuation.
+// removing gmt/utc
+// Adding the current-year
+// replacing day of the week tokens with the appropriate date format
+function get_possible_date_strings(date_string, extrema) {
+    var date_strings = [];
+
+    // Unify some common stuff first.
+    //
+    // Change /.: to -
+    date_string = date_string.replace(/[\/:\.]/g, '-');
+    date_string = date_string.toLowerCase();
+    date_string = date_string.replace(/gmt/g, "");
+    date_string = date_string.replace(/utc/g, "");
+
+    var date_name_mappings = {};
+
+    var cur = extrema.start.clone();
+    var now = moment.utc();
+    while (!cur.isAfter(extrema.end)) {
+        var month_day = cur.format("MM-DD");
+        // Deal with a couple of formats that moment doesn't produce but are used.
+        if (cur.format("dddd") == "Thursday") {
+            date_name_mappings["thurs"] = month_day;
+        } if (cur.format("dddd") == "Wednesday") {
+            date_name_mappings["weds"] = month_day;
+        }
+        date_name_mappings[cur.format("dd").toLowerCase()] = month_day;
+        date_name_mappings[cur.format("ddd").toLowerCase()] = month_day;
+        date_name_mappings[cur.format("dddd").toLowerCase()] = month_day;
+        date_name_mappings[cur.format("Do").toLowerCase()] = cur.format("DD");
+        var month = cur.format("MM");
+        date_name_mappings[cur.format("MMM").toLowerCase()] = month;
+        date_name_mappings[cur.format("MMMM").toLowerCase()] = month;
+        cur.add(1, 'days');
+    }
+
+    // Now make one where we map date names to their date
+    var tokens = date_string.split(" ");
+    tokens = _.map(tokens, function(part) {
+        if (date_name_mappings[part.toLowerCase()]) {
+            return date_name_mappings[part.toLowerCase()];
+        } else {
+            return part;
+        }
+    });
+    date_strings.push(tokens.join(" "));
+
+    // now make one wher we remove weekdays
+    tokens = date_string.split(" ");
+    tokens = _.map(tokens, function(part) {
+        if (date_name_mappings[part.toLowerCase()]) {
+            return "";
+        } else {
+            return part;
+        }
+    });
+    tokens = _.filter(tokens, function(i) { return i.length > 0; });
+    date_strings.push(tokens.join(" "));
+
+    // Now make some where we inject various date pieces into the string.
+    var now = moment.utc();
+    year = now.format("YYYY");
+    month = now.format("MM");
+    date_strings.slice().forEach(function(date_string) {
+        date_strings.push("" + year + "-" + date_string);
+    });
+    //console.log(date_strings);
+    //date_strings.push("" + year + month + date_string);
+    return date_strings;
 }
 
 // Make an attempt to parse a scheduling string. 
@@ -186,22 +234,7 @@ function parse_scheduling(input_string, options) {
     // Now build up some possible strings and try a bunch of patterns
     // to find a date in our range.
     var extrema = get_round_extrema(options);
-    date_string = parts.slice(2).join(" ");
-    // Change /.: to -
-    date_string = date_string.replace(/[\/:\.]/g, '-');
-    date_string = date_string.toLowerCase();
-    date_string = date_string.replace(/gmt/g, "");
-    date_string = date_string.replace(/utc/g, "");
-    var date_strings = [];
-    date_strings.push(date_string)
-    var now = moment.utc();
-    year = now.year();
-    month = now.month()+1;
-    date_strings.push("" + year + "-" + date_string);
-    date_strings.push("" + year + "-0" + date_string);
-    date_strings.push("" + year + "-" + month + "-" + date_string);
-    date_strings.push("" + year + "-" + month + "-0" + date_string);
-    //date_strings.push("" + year + month + date_string);
+    var date_strings = get_possible_date_strings(parts.slice(2).join(" "), extrema);
 
     var valid_in_bounds_dates = [];
     var valid_out_of_bounds_dates = [];
@@ -503,7 +536,6 @@ function update_result(service_account_auth, key, colname, result, callback){
                 return callback(err);
             }
             var result_cell = row[colname];
-            console.log(result_cell);
 
             //make the update to the cell
             //parse the links out of the function

--- a/spreadsheets.js
+++ b/spreadsheets.js
@@ -190,7 +190,7 @@ function get_possible_date_strings(date_string, extrema) {
     });
     date_strings.push(tokens.join(" "));
 
-    // now make one wher we remove weekdays
+    // now make one wher we remove date names completely.
     tokens = date_string.split(" ");
     tokens = _.map(tokens, function(part) {
         if (date_name_mappings[part.toLowerCase()]) {
@@ -202,15 +202,13 @@ function get_possible_date_strings(date_string, extrema) {
     tokens = _.filter(tokens, function(i) { return i.length > 0; });
     date_strings.push(tokens.join(" "));
 
-    // Now make some where we inject various date pieces into the string.
+    // Now make some where we inject the year at the beginning
     var now = moment.utc();
     year = now.format("YYYY");
     month = now.format("MM");
     date_strings.slice().forEach(function(date_string) {
         date_strings.push("" + year + "-" + date_string);
     });
-    //console.log(date_strings);
-    //date_strings.push("" + year + month + date_string);
     return date_strings;
 }
 

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -2,6 +2,10 @@ var assert = require('chai').assert;
 var moment = require("moment");
 var spreadsheets = require('../spreadsheets');
 
+
+
+var fmt = "YYYY-MM-DDTHH:mm:ssZZ";
+
 describe('scheduling', function() {
     //--------------------------------------------------------------------------
     describe('#get_round_extrema()', function () {
@@ -29,17 +33,17 @@ describe('scheduling', function() {
             options.extrema.iso_weekday = 1;
             options.extrema.reference_date = moment.utc("2016-04-07");
             var bounds = spreadsheets.get_round_extrema(options);
-            assert.equal(bounds.start.format(), "2016-04-04T11:00:00Z")
-            assert.equal(bounds.end.format(), "2016-04-11T11:00:00Z")
+            assert.equal(bounds.start.format(fmt), "2016-04-04T11:00:00+0000")
+            assert.equal(bounds.end.format(fmt), "2016-04-11T11:00:00+0000")
         });
         it("Test warning_hours", function() {
             options.extrema.iso_weekday = 1;
             options.extrema.reference_date = moment.utc("2016-04-07");
             options.extrema.warning_hours = 1;
             var bounds = spreadsheets.get_round_extrema(options);
-            assert.equal(bounds.start.format(), "2016-04-04T11:00:00Z");
-            assert.equal(bounds.end.format(), "2016-04-11T11:00:00Z");
-            assert.equal(bounds.warning.format(), "2016-04-11T10:00:00Z");
+            assert.equal(bounds.start.format(fmt), "2016-04-04T11:00:00+0000");
+            assert.equal(bounds.end.format(fmt), "2016-04-11T11:00:00+0000");
+            assert.equal(bounds.warning.format(fmt), "2016-04-11T10:00:00+0000");
         });
     });
     //--------------------------------------------------------------------------
@@ -61,7 +65,7 @@ describe('scheduling', function() {
             //options.extrema.reference_date = moment.utc("2016-04-15");
             function test_parse_scheduling(string, expected)  {
                 var results = spreadsheets.parse_scheduling(string, options);
-                assert.equal(results.date.format(), expected.date);
+                assert.equal(results.date.format(fmt), expected.date);
                 assert.equal(results.white, expected.white);
                 assert.equal(results.black, expected.black);
             }
@@ -69,7 +73,7 @@ describe('scheduling', function() {
                 "@autotelic v @explodingllama 4/16 @ 0900 GMT", {
                     white: "autotelic",
                     black: "explodingllama",
-                    date: "2016-04-16T09:00:00Z"
+                    date: "2016-04-16T09:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -77,7 +81,7 @@ describe('scheduling', function() {
                 {
                     white: "ronaldulyssesswanson",
                     black: "esolcneveton",
-                    date: "2016-04-17T14:00:00Z"
+                    date: "2016-04-17T14:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -85,7 +89,7 @@ describe('scheduling', function() {
                 {
                     white: "adrianchessnow",
                     black: "mydogeatslemons",
-                    date: "2016-04-15T23:00:00Z"
+                    date: "2016-04-15T23:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -93,7 +97,7 @@ describe('scheduling', function() {
                 {
                     white: "juansnow",
                     black: "jimcube27",
-                    date: "2016-04-17T10:30:00Z"
+                    date: "2016-04-17T10:30:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -101,7 +105,7 @@ describe('scheduling', function() {
                 {
                     white: "mrrobot",
                     black: "ashkanjah",
-                    date: "2016-04-16T14:00:00Z"
+                    date: "2016-04-16T14:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -109,7 +113,7 @@ describe('scheduling', function() {
                 {
                     white: "ronaldulyssesswanson",
                     black: "esolcneveton",
-                    date: "2016-04-16T14:00:00Z"
+                    date: "2016-04-16T14:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -117,7 +121,7 @@ describe('scheduling', function() {
                 {
                     white: "rreyv",
                     black: "krzem",
-                    date: "2016-04-17T15:00:00Z"
+                    date: "2016-04-17T15:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -125,7 +129,7 @@ describe('scheduling', function() {
                 {
                     white: "atrophied",
                     black: "jaivl",
-                    date: "2016-04-14T20:00:00Z"
+                    date: "2016-04-14T20:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -133,7 +137,7 @@ describe('scheduling', function() {
                 {
                     white: "modakshantanu",
                     black: "hakonj",
-                    date: "2016-04-14T07:00:00Z"
+                    date: "2016-04-14T07:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -141,7 +145,7 @@ describe('scheduling', function() {
                 {
                     white: "quirked",
                     black: "vishysoisse",
-                    date: "2016-04-14T21:00:00Z"
+                    date: "2016-04-14T21:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -149,7 +153,7 @@ describe('scheduling', function() {
                 {
                     white: "theino",
                     black: "cactus",
-                    date: "2016-04-14T02:30:00Z"
+                    date: "2016-04-14T02:30:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -157,7 +161,7 @@ describe('scheduling', function() {
                 {
                     white: "seb32",
                     black: "Petruchio",
-                    date: "2016-04-15T23:00:00Z"
+                    date: "2016-04-15T23:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -165,7 +169,7 @@ describe('scheduling', function() {
                 {
                     white: "soldadofiel",
                     black: "durchnachtundwind",
-                    date: "2016-04-13T23:09:00Z"
+                    date: "2016-04-13T23:09:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -173,7 +177,7 @@ describe('scheduling', function() {
                 {
                     white: "greyhawk",
                     black: "immortality",
-                    date: "2016-04-14T21:00:00Z"
+                    date: "2016-04-14T21:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -181,7 +185,7 @@ describe('scheduling', function() {
                 {
                     white: "soldadofiel",
                     black: "durchnachtundwind",
-                    date: "2016-04-13T23:09:00Z"
+                    date: "2016-04-13T23:09:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -189,7 +193,7 @@ describe('scheduling', function() {
                 {
                     white: "nacional100",
                     black: "tnan123",
-                    date: "2016-04-15T14:00:00Z"
+                    date: "2016-04-15T14:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -197,7 +201,7 @@ describe('scheduling', function() {
                 {
                     white: "hillrp",
                     black: "endrawes0",
-                    date: "2016-04-17T01:00:00Z"
+                    date: "2016-04-17T01:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -205,7 +209,7 @@ describe('scheduling', function() {
                 {
                     white: "saschlars",
                     black: "preserve",
-                    date: "2016-04-16T12:00:00Z"
+                    date: "2016-04-16T12:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -213,7 +217,7 @@ describe('scheduling', function() {
                 {
                     white: "modakshantanu",
                     black: "hakonj",
-                    date: "2016-04-14T15:00:00Z"
+                    date: "2016-04-14T15:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -221,7 +225,7 @@ describe('scheduling', function() {
                 {
                     white: "ihaterbf",
                     black: "hyzer",
-                    date: "2016-04-16T22:00:00Z"
+                    date: "2016-04-16T22:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -229,7 +233,7 @@ describe('scheduling', function() {
                 {
                     white: "djcrisce",
                     black: "zantawb",
-                    date: "2016-04-15T00:00:00Z"
+                    date: "2016-04-15T00:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -237,7 +241,7 @@ describe('scheduling', function() {
                 {
                     white: "jptriton",
                     black: "cyanfish",
-                    date: "2016-04-14T18:00:00Z"
+                    date: "2016-04-14T18:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -245,7 +249,7 @@ describe('scheduling', function() {
                 {
                     white: "narud",
                     black: "lakinwecker",
-                    date: "2016-04-16T17:00:00Z"
+                    date: "2016-04-16T17:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -253,7 +257,7 @@ describe('scheduling', function() {
                 {
                     white: "jyr",
                     black: "droodjerky",
-                    date: "2016-04-15T17:00:00Z"
+                    date: "2016-04-15T17:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -261,7 +265,7 @@ describe('scheduling', function() {
                 {
                     white: "chill5555",
                     black: "doganof",
-                    date: "2016-04-15T17:00:00Z"
+                    date: "2016-04-15T17:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -269,7 +273,7 @@ describe('scheduling', function() {
                 {
                     white: "oldtom",
                     black: "bramminator",
-                    date: "2016-04-17T16:15:00Z"
+                    date: "2016-04-17T16:15:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -277,7 +281,7 @@ describe('scheduling', function() {
                 {
                     white: "ctorh",
                     black: "practicedave",
-                    date: "2016-04-18T18:00:00Z"
+                    date: "2016-04-18T18:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -285,7 +289,7 @@ describe('scheduling', function() {
                 {
                     white: "boviced",
                     black: "hoxhound",
-                    date: "2016-04-14T16:00:00Z"
+                    date: "2016-04-14T16:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -293,7 +297,7 @@ describe('scheduling', function() {
                 {
                     white: "pasternak",
                     black: "riemannn",
-                    date: "2016-04-14T20:00:00Z"
+                    date: "2016-04-14T20:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -301,7 +305,7 @@ describe('scheduling', function() {
                 {
                     white: "angborxley",
                     black: "theknug",
-                    date: "2016-04-17T13:30:00Z"
+                    date: "2016-04-17T13:30:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -309,7 +313,7 @@ describe('scheduling', function() {
                 {
                     white: "modakshantanu",
                     black: "hakonj",
-                    date: "2016-04-13T07:00:00Z"
+                    date: "2016-04-13T07:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -317,7 +321,7 @@ describe('scheduling', function() {
                 {
                     white: "U0DJTJ15W",
                     black: "U0YUPPF4H",
-                    date: "2016-04-16T00:00:00Z"
+                    date: "2016-04-16T00:00:00+0000"
                 }
             );
             test_parse_scheduling(
@@ -325,7 +329,23 @@ describe('scheduling', function() {
                 {
                     white: "U0DJTJ15W",
                     black: "U0YUPPF4H",
-                    date: "2016-04-17T20:00:00Z"
+                    date: "2016-04-17T20:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "imakethenews vs. riemannn  4/17 00:00 GMT",
+                {
+                    white: "imakethenews",
+                    black: "riemannn",
+                    date: "2016-04-17T00:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "resonantpillow vs steiger07 : sunday 17.04. @ 16:00 GMT",
+                {
+                    white: "resonantpillow",
+                    black: "steiger07",
+                    date: "2016-04-17T16:00:00+0000"
                 }
             );
         });
@@ -375,11 +395,6 @@ describe('scheduling', function() {
                     "warning_hours": 1
                 }
             };
-            function test_parse_scheduling(string, expected)  {
-                assert.equal(results.date.format(), expected.date);
-                assert.equal(results.white, expected.white);
-                assert.equal(results.black, expected.black);
-            }
             var results = spreadsheets.parse_scheduling(
                 "@autotelic v @explodingllama 4/18 @ 2200 GMT",
                 options
@@ -468,10 +483,10 @@ describe('results', function(){
                 }
             );
             test_parse_result(
-                "<@U1234567> 1/2X-1/2X <@U2345678>", {
+                "<@U1234567> 1/2Z-1/2Z <@U2345678>", {
                     white: "<@U1234567>",
                     black: "<@U2345678>",
-                    result: "1/2X-1/2X"
+                    result: "1/2Z-1/2Z"
                 }
             );
             test_parse_result(

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -77,14 +77,6 @@ describe('scheduling', function() {
                 }
             );
             test_parse_scheduling(
-                "@ronaldulyssesswanson – @esolcneveton rescheduled to Sunday, April 17th at 14:00 GMT.",
-                {
-                    white: "ronaldulyssesswanson",
-                    black: "esolcneveton",
-                    date: "2016-04-17T14:00:00+0000"
-                }
-            );
-            test_parse_scheduling(
                 "@adrianchessnow:  v @mydogeatslemons: 4/15 2300 GMT",
                 {
                     white: "adrianchessnow",
@@ -105,14 +97,6 @@ describe('scheduling', function() {
                 {
                     white: "mrrobot",
                     black: "ashkanjah",
-                    date: "2016-04-16T14:00:00+0000"
-                }
-            );
-            test_parse_scheduling(
-                "@ronaldulyssesswanson – @esolcneveton on Saturday, April 16th at 14:00 GMT.",
-                {
-                    white: "ronaldulyssesswanson",
-                    black: "esolcneveton",
                     date: "2016-04-16T14:00:00+0000"
                 }
             );
@@ -346,6 +330,30 @@ describe('scheduling', function() {
                     white: "resonantpillow",
                     black: "steiger07",
                     date: "2016-04-17T16:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "supervj: v ecstaticbroccoli Wednesday 19:00 GMT",
+                {
+                    white: "supervj",
+                    black: "ecstaticbroccoli",
+                    date: "2016-04-13T19:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "@ronaldulyssesswanson – @esolcneveton on Saturday, April 16th at 14:00 GMT.",
+                {
+                    white: "ronaldulyssesswanson",
+                    black: "esolcneveton",
+                    date: "2016-04-16T14:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "@ronaldulyssesswanson – @esolcneveton rescheduled to Sunday, April 17th at 14:00 GMT.",
+                {
+                    white: "ronaldulyssesswanson",
+                    black: "esolcneveton",
+                    date: "2016-04-17T14:00:00+0000"
                 }
             );
         });

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -56,6 +56,12 @@ describe('scheduling', function() {
                 "warning_hours": 1
             }
         };
+        function test_parse_scheduling(string, expected)  {
+            var results = spreadsheets.parse_scheduling(string, options);
+            assert.equal(results.date.format(fmt), expected.date);
+            assert.equal(results.white, expected.white);
+            assert.equal(results.black, expected.black);
+        }
         it("Test team-scheduling messages", function() {
             options.extrema.reference_date = moment.utc("2016-04-15");
 
@@ -63,12 +69,6 @@ describe('scheduling', function() {
         });
         it("Test lonewolf-scheduling messages", function() {
             //options.extrema.reference_date = moment.utc("2016-04-15");
-            function test_parse_scheduling(string, expected)  {
-                var results = spreadsheets.parse_scheduling(string, options);
-                assert.equal(results.date.format(fmt), expected.date);
-                assert.equal(results.white, expected.white);
-                assert.equal(results.black, expected.black);
-            }
             test_parse_scheduling(
                 "@autotelic v @explodingllama 4/16 @ 0900 GMT", {
                     white: "autotelic",
@@ -354,6 +354,57 @@ describe('scheduling', function() {
                     white: "ronaldulyssesswanson",
                     black: "esolcneveton",
                     date: "2016-04-17T14:00:00+0000"
+                }
+            );
+        });
+        it("Test lonewolf-scheduling messages #2", function() {
+            options.extrema.reference_date = moment.utc("2016-04-28");
+            test_parse_scheduling(
+                "steiger07 vs matuiss2 Sun 01.05.2016 @ 16:00 GMT",
+                {
+                    white: "steiger07",
+                    black: "matuiss2",
+                    date: "2016-05-01T16:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "steiger07 vs matuiss2 01.05.2016 @ 16:00 GMT",
+                {
+                    white: "steiger07",
+                    black: "matuiss2",
+                    date: "2016-05-01T16:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "@steiger07 vs @matuiss2 5/1 @ 16:00 GMT",
+                {
+                    white: "steiger07",
+                    black: "matuiss2",
+                    date: "2016-05-01T16:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "@theknug: vs. @fradtheimpaler Sat. 4/30 at 14:00 GMT",
+                {
+                    white: "theknug",
+                    black: "fradtheimpaler",
+                    date: "2016-04-30T14:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "@theknug - @fradtheimpaler saturday 30/4 14 GMT",
+                {
+                    white: "theknug",
+                    black: "fradtheimpaler",
+                    date: "2016-04-30T14:00:00+0000"
+                }
+            );
+            test_parse_scheduling(
+                "captncarter vs Kimaga 17.00 GMT 27-04",
+                {
+                    white: "captncarter",
+                    black: "Kimaga",
+                    date: "2016-04-27T17:00:00+0000"
                 }
             );
         });


### PR DESCRIPTION
This version parses more date formats and runs slightly faster.  It accomplishes this by replacing weekday and month names and day-th (1st, 3rd etc) with the appropriate numbers and removing a bunch of other formats that we used to deal with specific formats. 

Also it removes punctuation at word-boundaries and refactors the methods to make them a bit more maintanable.

It fixes the tests to use a specific format and fixes the draw tests for 1/2Z and 1/2Z