### PR TITLE
Add travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js: "5"
+install: npm install
+script: mocha

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js: "5"
 install: npm install
-script: mocha
+script: mocha --timeout 5000

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "chesster",
+  "version": "1.0.0",
+  "description": "Bot for Lichess4545 Slack group",
+  "main": "chesster.js",
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "async": "^2.0.0-rc.3",
+    "botkit": "^0.1.1",
+    "chai": "^3.5.0",
+    "fast-levenshtein": "^1.1.3",
+    "google-spreadsheet": "^2.0.1",
+    "moment": "^2.13.0",
+    "underscore": "^1.8.3"
+  },
+  "devDependencies": {
+    "mocha": "^2.4.5"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aweidner/Chesster.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/aweidner/Chesster/issues"
+  },
+  "homepage": "https://github.com/aweidner/Chesster#readme"
+}

--- a/package.json
+++ b/package.json
@@ -7,28 +7,28 @@
     "test": "test"
   },
   "dependencies": {
-    "async": "^2.0.0-rc.3",
-    "botkit": "^0.1.1",
-    "chai": "^3.5.0",
-    "fast-levenshtein": "^1.1.3",
-    "google-spreadsheet": "^2.0.1",
-    "moment": "^2.13.0",
-    "underscore": "^1.8.3"
+    "async": "2.0.0-rc.3",
+    "botkit": "0.1.1",
+    "chai": "3.5.0",
+    "fast-levenshtein": "1.1.3",
+    "google-spreadsheet": "2.0.1",
+    "moment": "2.13.0",
+    "underscore": "1.8.3"
   },
   "devDependencies": {
-    "mocha": "^2.4.5"
+    "mocha": "2.4.5"
   },
   "scripts": {
     "test": "mocha"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aweidner/Chesster.git"
+    "url": "git+https://github.com/endrawes0/Chesster.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/aweidner/Chesster/issues"
+    "url": "https://github.com/endrawes0/Chesster/issues"
   },
-  "homepage": "https://github.com/aweidner/Chesster#readme"
+  "homepage": "https://github.com/endrawes0/Chesster"
 }


### PR DESCRIPTION
This isn't ready for merge yet, just want to get some discussion going on this.  The steps for travis are basically simple.  Somebody (most likely @endrawes0) needs to sign up with travis and have admin (?) access to the Chesster repository.  Then we just add this .travis.yml file and all pull requests, branches, etc will be built automatically.

The integration tests run fine on Travis, so unless there is a reason not to run them, we can run them as part of our standard build.

In order to allow travis to download dependencies, I also added a default package.json with our current  deps.  Right now it's set to download the latest, but we can lock them to specific versions as well (I think we discussed that before).