### PR TITLE
Adds a local database and uses it to cache ratings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ service_account_key.js
 slack_token.js
 coverage
 test_service_account_key.js
+db/database.sqlite

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,6 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "chesster"
 
 
-  config.vm.provision :shell, :path => "./setup/vagrant-dependencies.sh"
+  config.vm.provision :shell, :path => "./setup/vagrant/vagrant-dependencies.sh"
 
 end

--- a/config/config.js
+++ b/config/config.js
@@ -4,6 +4,19 @@ var token = require("./slack_token.js").token;
 var private_key = require("./service_account_key.js").key;
 
 var config = {
+    // Unfortunately this all has to be at the top level due to sequelize-cli
+    "database": "",
+    "username": "",
+    "password": "",
+    "dialect": "sqlite",
+    "logging": false,
+	"pool": {
+		"max": 5,
+		"min": 0,
+		"idle": 10000
+	},
+    "storage": "./db/database.sqlite",
+
     "token": token,
     "links": {
         "source": "https://github.com/endrawes0/Chesster"
@@ -150,4 +163,4 @@ var config = {
         "unstable_bot": "45+45"
     },
 }
-module.exports.config = config;
+module.exports = config;

--- a/config/testconfig.js
+++ b/config/testconfig.js
@@ -3,7 +3,7 @@
 var token = require("./slack_token.js").token;
 var private_key = require("./test_service_account_key.js").key;
 
-var config = require("./config.js").config;
+var config = require("./config.js");
 config["leagues"]["45+45"]["spreadsheet"]["key"] = "1BeRN76zaB_uCCrCra2yTEEw_r6C5_b8P59aN_BrJsyA";
 config["leagues"]["45+45"]["spreadsheet"]["serviceAccountAuth"] = {
     "client_email": "tesster@chesster-lichess-4545-bot.iam.gserviceaccount.com",
@@ -20,4 +20,4 @@ config["leagues"]["45+45"]["gamelinks"]["channel"] = "unstable_bot";
 config["leagues"]["lonewolf"]["scheduling"]["channel"] = "unstable_bot-lonewolf";
 config["leagues"]["lonewolf"]["results"]["channel"] = "unstable_bot-lonewolf";
 config["leagues"]["lonewolf"]["gamelinks"]["channel"] = "unstable_bot-lonewolf";
-module.exports.config = config;
+module.exports = config;

--- a/db/empty.txt
+++ b/db/empty.txt
@@ -1,0 +1,1 @@
+So we can commit the directory, but ignore the db inside of it.

--- a/migrations/20160625024216-adding_rating_table.js
+++ b/migrations/20160625024216-adding_rating_table.js
@@ -1,0 +1,45 @@
+'use strict';
+
+module.exports = {
+    up: function (queryInterface, Sequelize) {
+        /*
+            Add altering commands here.
+            Return a promise to correctly handle asynchronicity.
+
+            Example:
+            return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+        */
+        return queryInterface.createTable('LichessRatings', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            lichessUserName: Sequelize.STRING, // Comes from lichess
+            rating: {
+                type: Sequelize.INTEGER, allowNull: true
+            },
+            lastCheckedAt: {
+                type: Sequelize.DATE, allowNull: true
+            },
+            // These two are automatically added to a model by sequelize
+            createdAt: {
+                type: Sequelize.DATE, allowNull: true
+            },
+            updatedAt: {
+                type: Sequelize.DATE, allowNull: true
+            }
+        });
+    },
+
+    down: function (queryInterface, Sequelize) {
+        /*
+            Add reverting commands here.
+            Return a promise to correctly handle asynchronicity.
+
+            Example:
+            return queryInterface.dropTable('users');
+        */
+        return queryInterface.dropTable('LichessRatings');
+    }
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "moment": "2.13.0",
     "q": "1.4.1",
     "string-format": "0.5.0",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "sequelize": "3.23.4",
+    "sequelize-cli": "2.4.0",
+    "sqlite3": "3.1.4",
+    "async-lock": "0.3.8"
   },
   "devDependencies": {
     "mocha": "2.4.5"

--- a/src/league.js
+++ b/src/league.js
@@ -187,14 +187,8 @@ league_attributes = {
                 _.each(self._teams, function(team) {
                     _.each(team.roster, function(player) {
                         if (player && player.name) {
-                            if (firstRosterUpdate && player.rating) {
-                                lichess.setPlayerRating(player.name, player.rating);
-                            }
-                            lichess.getPlayerRating(player.name, true).then(function(rating) {
+                            lichess.getPlayerRating(player.name).then(function(rating) {
                                 player.rating = rating;
-                                self._playerRatingsLastUpdates[player.name] = moment.utc();
-                            }, function(error) {
-                                console.error("Error updating rating: " + JSON.stringify(error));
                             });
                         }
                     });

--- a/src/lichess.js
+++ b/src/lichess.js
@@ -105,10 +105,9 @@ var ratingFunctions = (function() {
         return getPlayerByName(name, isBackground).then(function(result) {
             _playerIsInQueue[name] = undefined;
             var rating = result.json.perfs.classical.rating;
-            var doneWithDB = Q.defer();
             // Get the writable lock for the database.
-            return db.lock(doneWithDB.promise).then(function(models) {
-                return models.LichessRating.findOrCreate({
+            return db.lock().then(function(unlock) {
+                return db.LichessRating.findOrCreate({
                     where: { lichessUserName: name }
                 }).then(function(lichessRatings) {
                     lichessRating = lichessRatings[0];
@@ -119,15 +118,15 @@ var ratingFunctions = (function() {
                             name: name,
                             rating: rating
                         }));
-                        doneWithDB.resolve();
+                        unlock.resolve();
                     }).catch(function(error) {
-                        doneWithDB.reject();
+                        unlock.resolve();
                     });
                     return rating;
                 });
             });
         }).catch(function(error) {
-            doneWithDB.reject();
+            console.error("Error getting player by name: " + error);
         });
     }
 
@@ -138,14 +137,13 @@ var ratingFunctions = (function() {
     function getPlayerRating(name){
         var name = name.toLowerCase();
 
-        var doneWithDB = Q.defer();
         // Get the writable lock for the database.
-        return db.lock(doneWithDB.promise).then(function(models) {
+        return db.lock().then(function(unlock) {
             // Ensure we have a record.
-            return models.LichessRating.findOrCreate({
+            return db.LichessRating.findOrCreate({
                 where: { lichessUserName: name }
             }).then(function(lichessRating) {
-                doneWithDB.resolve();
+                unlock.resolve();
                 lichessRating = lichessRating[0];
 
                 var _30MinsAgo = moment.utc().subtract(30, 'minutes');

--- a/src/models.js
+++ b/src/models.js
@@ -1,0 +1,79 @@
+'use strict'
+
+//------------------------------------------------------------------------------
+// Models for our locally stored data
+//------------------------------------------------------------------------------
+var Sequelize = require('sequelize');
+var Q = require('q');
+var AsyncLock = require('async-lock');
+
+
+var exports = (function() {
+    var _models = {};
+    var _lockQueue = [];
+    var _lock = new AsyncLock();
+
+    //--------------------------------------------------------------------------
+    // A lock that we can use to ensure that any writing to the database is 
+    // finished before another writer starts.
+    //
+    // Parameters: donePromise - the promise object that will be resolved when
+    //             the querying is done such that the next person may start their
+    //             query.
+    //--------------------------------------------------------------------------
+    function lock(donePromise) {
+        var lockDeferred = Q.defer();
+        _lock.acquire("chesster", function() {
+            lockDeferred.resolve(_models);
+            return donePromise;
+        });
+        return lockDeferred.promise;
+    }
+
+    //--------------------------------------------------------------------------
+    function defineModels(sequelize) {
+        var LichessRating = sequelize.define('LichessRating', {
+            id: {
+                type: Sequelize.INTEGER,
+                autoIncrement: true,
+                primaryKey: true
+            },
+            lichessUserName: Sequelize.STRING, // Comes from lichess
+            rating: {
+                type: Sequelize.INTEGER, allowNull: true
+            },
+            lastCheckedAt: {
+                type: Sequelize.DATE, allowNull: true
+            }
+        });
+        return {
+            LichessRating: LichessRating
+        };
+    }
+
+    //--------------------------------------------------------------------------
+    // Connection function that ensures we have a connection and the models
+    // are defined.
+    //
+    // Parameters: config - the config option that contains the database
+    //                      information.
+    //--------------------------------------------------------------------------
+    function connect(config) {
+        var sequelize = new Sequelize(config.database, config.username, config.password, config);
+        var deferred = Q.defer();
+        return sequelize.authenticate().then(function() {
+            _models = defineModels(sequelize);
+            deferred.resolve(_models);
+        }).catch(function(error) {
+            console.error("Unable to connect to database: " + error);
+            deferred.reject(error);
+        });
+        return deferred.promise;
+    }
+    return {
+        connect: connect,
+        lock: lock
+    };
+})();
+
+module.exports = exports

--- a/src/models.js
+++ b/src/models.js
@@ -17,22 +17,22 @@ var exports = (function() {
     // A lock that we can use to ensure that any writing to the database is 
     // finished before another writer starts.
     //
-    // Parameters: donePromise - the promise object that will be resolved when
-    //             the querying is done such that the next person may start their
-    //             query.
+    // A donePromise will be passed into the deferred, this donePromise should
+    // always be resolved when you are done with the database.
     //--------------------------------------------------------------------------
-    function lock(donePromise) {
+    function lock() {
         var lockDeferred = Q.defer();
         _lock.acquire("chesster", function() {
-            lockDeferred.resolve(_models);
-            return donePromise;
+            var unlock = Q.defer();
+            lockDeferred.resolve(unlock);
+            return unlock.promise;
         });
         return lockDeferred.promise;
     }
 
     //--------------------------------------------------------------------------
     function defineModels(sequelize) {
-        var LichessRating = sequelize.define('LichessRating', {
+        module.exports.LichessRating = sequelize.define('LichessRating', {
             id: {
                 type: Sequelize.INTEGER,
                 autoIncrement: true,
@@ -46,9 +46,6 @@ var exports = (function() {
                 type: Sequelize.DATE, allowNull: true
             }
         });
-        return {
-            LichessRating: LichessRating
-        };
     }
 
     //--------------------------------------------------------------------------
@@ -62,8 +59,8 @@ var exports = (function() {
         var sequelize = new Sequelize(config.database, config.username, config.password, config);
         var deferred = Q.defer();
         return sequelize.authenticate().then(function() {
-            _models = defineModels(sequelize);
-            deferred.resolve(_models);
+            defineModels(sequelize);
+            deferred.resolve();
         }).catch(function(error) {
             console.error("Unable to connect to database: " + error);
             deferred.reject(error);

--- a/src/slack.js
+++ b/src/slack.js
@@ -262,7 +262,6 @@ function hears(options, callback) {
     var options = _.extend({}, DEFAULT_HEARS_OPTIONS, options);
     self.controller.hears(options.patterns, options.messageTypes, function(bot, message) {
         return botExceptionHandler(bot, message, Q.fcall(function() {
-            message.controller = self;
             message.player = users.getByNameOrID(message.user);
             // This will occur if a new player uses a chesster command
             // within their first 2 minutes of having joined. :)
@@ -298,7 +297,6 @@ function on(options, callback) {
     var options = _.extend({}, DEFAULT_ON_OPTIONS, options);
     self.controller.on(options.event, function(bot, message) {
         return botExceptionHandler(bot, message, Q.fcall(function() {
-            message.controller = self;
             message.player = users.getByNameOrID(message.user);
             if (message.player) {
                 message.player.localTime = localTime;


### PR DESCRIPTION
This commit adds a local sqlite3 database and uses said database to cache player ratings.

This is ready for comments. The primary focus should be on the database integration.  Some notes:

1. I had to write our own locking mechanism to ensure that all queries are run to completion before a new one is run. This will slow us down. We should be able to turn on the WAL and ONLY run writes through this locking mechanism moving forward.
2. I'm not a big fan of how I've had to organize the config and various files - but I'm not sure we can do any better, considering. 
3. sequelize-cli is required to run migrations and make migrations etc. I've been running it locally like so: ```./node_modules/sequelize-cli/bin/sequelize --config ./config/config.js db:migrate``` but we'll want to figure something else out for that. I think we can add custom commands to our package.json, so maybe we can do it that way.