### PR TITLE
Vagrant and league recognition fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,6 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "chesster"
 
 
-  config.vm.provision :shell, :path => "./setup/vagrant-dependencies.sh"
-
+  config.vm.provision :shell, :path => "./setup/vagrant/vagrant-dependencies.sh"
+  config.vm.provision :shell, :path => "./sysadmin/vagrant/startup.sh", run: "always"
 end

--- a/setup/vagrant/vagrant-dependencies.sh
+++ b/setup/vagrant/vagrant-dependencies.sh
@@ -4,11 +4,4 @@ curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ln -s /vagrant/ /home/vagrant/chesster
 cd ~/chesster
-sudo npm install -g --save botkit
-sudo npm install -g --save async
-sudo npm install -g --save fast-levenshtein
-sudo npm install -g --save google-spreadsheet
-sudo npm install -g --save mocha
-sudo npm install -g --save chai
-sudo npm install -g --save moment
-sudo npm install -g --save underscore
+sudo npm install

--- a/src/league.js
+++ b/src/league.js
@@ -283,7 +283,7 @@ league_attributes = {
     // Returns whether someone is a moderator or not.
     //--------------------------------------------------------------------------
     'isModerator': function(name) {
-        return _.includes(this.options.moderator, name);
+        return _.includes(this.options.moderators, name);
     },
     //--------------------------------------------------------------------------
     // Prepare a debug message for this league

--- a/src/slack.js
+++ b/src/slack.js
@@ -7,7 +7,7 @@ var _ = require("underscore");
 var league = require("./league.js");
 var fuzzy = require("./fuzzy_match.js");
 
-function StopControllerError () {}
+function StopControllerError (error) { this.error = error; }
 StopControllerError.prototype = new Error();
 
 //
@@ -217,7 +217,7 @@ function withLeague(bot, message, config) {
         });
         var matchingLeagueNames = _.keys(possibleLeagues);
         if (matchingLeagueNames.length > 1) {
-            throw new Error("Ambiguous leagues.");
+            throw new StopControllerError("Ambiguous leagues.");
         }
         if (matchingLeagueNames.length == 1) {
             l = _.values(possibleLeagues)[0];
@@ -236,7 +236,6 @@ function withLeague(bot, message, config) {
                 return l;
             }
         }
-
         return;
     });
 }

--- a/sysadmin/vagrant/startup.sh
+++ b/sysadmin/vagrant/startup.sh
@@ -1,0 +1,1 @@
+sudo npm update


### PR DESCRIPTION
The issue is, we were only handling errors of the particular type: `StopControllerError`. The error was of type `Error` and thus went unhandled.

Also, we were passing an error message but it was never stored so dumping that error to the logs was just ignored.

I have saved it as a member of `StopControllerError`.

Updated Vagrantfile to include a script to run on startup - to acquire the most recent versions of our dependencies.

Lastly, update the location of the vagrant-dependencies.sh to be run on first `vagrant up` after a `vagrant destroy`. 