### PR TITLE
Fixing scheduling adding logging

### DIFF
--- a/src/chesster.js
+++ b/src/chesster.js
@@ -538,17 +538,19 @@ function(bot, message) {
     }
     var schedulingOptions = message.league.options.scheduling;
     if (!schedulingOptions) {
-        winston.error("{} league doesn't have scheduling options!?".format(message.league.options.name));
+        winston.error("[SCHEDULING] {} league doesn't have scheduling options!?".format(message.league.options.name));
         return;
     } 
     var spreadsheetOptions = message.league.options.spreadsheet;
     if (!spreadsheetOptions) {
-        winston.error("{} league doesn't have spreadsheet options!?".format(message.league.options.name));
+        winston.error("[SCHEDULING] {} league doesn't have spreadsheet options!?".format(message.league.options.name));
         return;
     } 
     if (!_.isEqual(channel.name, schedulingOptions.channel)) {
         return;
     }
+
+    winston.log("[SCHEDULING] Message received in scheduling channel, and ready to parse: {}".format(message.text));
 
     var isPotentialSchedule = false;
     var referencesSlackUsers = false;
@@ -566,6 +568,9 @@ function(bot, message) {
     } catch (e) {
         if (!(e instanceof (spreadsheets.ScheduleParsingError))) {
             throw e; // let others bubble up
+        } else {
+            winston.log("[SCHEDULING] Received an exception: {}".format(JSON.stringify(e)));
+            winston.log("[SCHEDULING] Stack: {}".format(e.stack));
         }
     }
 
@@ -574,6 +579,7 @@ function(bot, message) {
         return;
     }
 
+    winston.log("[SCHEDULING] Checking to see if they are valid named players");
     // Step 2. See if we have valid named players
     var white = users.getByNameOrID(results.white);
     var black = users.getByNameOrID(results.black);
@@ -583,12 +589,14 @@ function(bot, message) {
         referencesSlackUsers = true;
     }
 
+    winston.log("[SCHEDULING] Attempting to update the spreadsheet.");
     // Step 3. attempt to update the spreadsheet
     spreadsheets.updateSchedule(
         spreadsheetOptions,
         schedulingOptions,
         results,
         function(err, reversed) {
+            winston.log("[SCHEDULING] Spreadsheet callback invoked: {} / {}.".format(err, reversed));
             if (err) {
                 if (_.includes(err, "Unable to find pairing.")) {
                     hasPairing = false;

--- a/src/chesster.js
+++ b/src/chesster.js
@@ -529,25 +529,31 @@ chesster.on({
     middleware: [slack.withLeague]
 },
 function(bot, message) {
+    var deferred = Q.defer();
     if (!message.league) {
-        return;
+        deferred.resolve();
+        return deferred.promise;
     }
     var channel = channels.byId[message.channel];
     if (!channel) {
-        return;
+        deferred.resolve();
+        return deferred.promise;
     }
     var schedulingOptions = message.league.options.scheduling;
     if (!schedulingOptions) {
         winston.error("[SCHEDULING] {} league doesn't have scheduling options!?".format(message.league.options.name));
-        return;
+        deferred.resolve();
+        return deferred.promise;
     } 
     var spreadsheetOptions = message.league.options.spreadsheet;
     if (!spreadsheetOptions) {
         winston.error("[SCHEDULING] {} league doesn't have spreadsheet options!?".format(message.league.options.name));
-        return;
+        deferred.resolve();
+        return deferred.promise;
     } 
     if (!_.isEqual(channel.name, schedulingOptions.channel)) {
-        return;
+        deferred.resolve();
+        return deferred.promise;
     }
 
     winston.log("[SCHEDULING] Message received in scheduling channel, and ready to parse: {}".format(message.text));
@@ -602,7 +608,7 @@ function(bot, message) {
                     hasPairing = false;
                 } else {
                     bot.reply(message, "Something went wrong. Notify a mod");
-                    throw new Error("Error updating scheduling sheet: " + err);
+                    deferred.reject("Error updating scheduling sheet: " + err);
                 }
             } else {
                 hasPairing = true;
@@ -643,8 +649,10 @@ function(bot, message) {
                 [white.name, black.name], {
                 results, white, black
             });
+            deferred.resolve();
         }
     );
+    return deferred.promise;
 });
 
 

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -432,6 +432,17 @@ describe('scheduling', function() {
                 }
             );
         });
+        it("Test lonewolf-scheduling messages #3", function() {
+            options.extrema.referenceDate = moment.utc("2016-07-27");
+            testParseScheduling(
+                "joecupojoe vs carbon752 7/28 23:30",
+                {
+                    white: "joecupojoe",
+                    black: "carbon752",
+                    date: "2016-07-28T23:30:00+0000"
+                }
+            );
+        });
         it("Test lonewolf-scheduling messages that are out of bounds", function() {
             var options = {
                 "extrema": {


### PR DESCRIPTION
This adds a test case for one of the recent failing formats and adds some logging. It also changes the spreadsheet call to use a deferred. This would be far more elegant if the spreadsheet API also used a deferred, but I don't have time to do that at the moment.  This should, at least, help us figure out the issue.

At this point, I think it's not a failure to parse the scheduling information that's failing, I suspect that google docs is rate limiting us, or otherwise our google docs requests are failing. Those are a non-promise based API being used within a promise, so I suspect they might be raising an exception or otherwise erroring in a way that isn't being logged or handled.