### PR TITLE
Adding more test cases, this proves that it's not the date parsing.

### DIFF
--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -435,11 +435,43 @@ describe('scheduling', function() {
         it("Test lonewolf-scheduling messages #3", function() {
             options.extrema.referenceDate = moment.utc("2016-07-27");
             testParseScheduling(
+                "joecupojoe vs carbon752 7/30 @ 13:30 GMT",
+                {
+                    white: "joecupojoe",
+                    black: "carbon752",
+                    date: "2016-07-30T13:30:00+0000"
+                }
+            );
+            testParseScheduling(
+                "joecupojoe carbon752 7/30 @ 13:30 GMT",
+                {
+                    white: "joecupojoe",
+                    black: "carbon752",
+                    date: "2016-07-30T13:30:00+0000"
+                }
+            );
+            testParseScheduling(
+                "joecupojoe vs carbon752 7/30 13:30",
+                {
+                    white: "joecupojoe",
+                    black: "carbon752",
+                    date: "2016-07-30T13:30:00+0000"
+                }
+            );
+            testParseScheduling(
                 "joecupojoe vs carbon752 7/28 23:30",
                 {
                     white: "joecupojoe",
                     black: "carbon752",
                     date: "2016-07-28T23:30:00+0000"
+                }
+            );
+            testParseScheduling(
+                "heidman vs icendoan 7/30 @ 10:30",
+                {
+                    white: "heidman",
+                    black: "icendoan",
+                    date: "2016-07-30T10:30:00+0000"
                 }
             );
         });

--- a/test/test_spreadsheets.js
+++ b/test/test_spreadsheets.js
@@ -475,6 +475,25 @@ describe('scheduling', function() {
                 }
             );
         });
+        it("Test lonewolf-scheduling messages #3", function() {
+            options.extrema.referenceDate = moment.utc("2016-07-17");
+            testParseScheduling(
+                "p_implies_q vs hairbert 7/17 13:30",
+                {
+                    white: "p_implies_q",
+                    black: "hairbert",
+                    date: "2016-07-17T13:30:00+0000"
+                }
+            );
+            testParseScheduling(
+                "p_implies_q vs hairbert 07/17 @13:30",
+                {
+                    white: "p_implies_q",
+                    black: "hairbert",
+                    date: "2016-07-17T13:30:00+0000"
+                }
+            );
+        });
         it("Test lonewolf-scheduling messages that are out of bounds", function() {
             var options = {
                 "extrema": {


### PR DESCRIPTION
This doesn't fix anything, but it proves that it's not the scheduling message format that is causing the issue as all of the ones that I've recorded thus far work without problems in the test.