### PR TITLE
in single-purpose channels, ONLY use channel name for league detection.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -153,7 +153,7 @@ rules:
   max-len: 0
   max-nested-callbacks: 0
   max-params: 0
-  max-statements: [2, 600]
+  max-statements: [2, 50]
   new-cap: 0
   new-parens: 0
   newline-after-var: 0

--- a/src/chesster.js
+++ b/src/chesster.js
@@ -528,52 +528,35 @@ function schedulingReplyCantFindUser(bot, message) {
 // Scheduling will occur on any message
 chesster.on({
     event: 'ambient',
-    middleware: [slack.withLeague]
+    middleware: [slack.withLeagueByChannelName]
 },
 function(bot, message) {
     var channel = channels.byId[message.channel];
-    var schedule_trace = _.noop;
-    if (channel) {
-        if (channel.name === "unstable_bot-lonewolf" || channel.name === "unstable_bot" || channel.name === "team-scheduling" || channel.name === "lonewolf-scheduling" || channel.name === "team-results" || channel.name === "team-gamelinks" || channel.name === "lonewolf-results" || channel.name === "lonewolf-gamelinks") {
-            schedule_trace = function(trace_message) {
-                winston.debug("[Scheduling][Message: {}]: {}".format(message.text, trace_message));
-            }
-        }
-    }
-    schedule_trace("1. Detecting Scheduling message");
     var deferred = Q.defer();
     if (!message.league) {
-        schedule_trace("2. No League");
         deferred.resolve();
         return deferred.promise;
     }
-    schedule_trace("3. Checking Channel");
     if (!channel) {
-        schedule_trace("4. no channel");
         deferred.resolve();
         return deferred.promise;
     }
-    schedule_trace("5. Checking Scheduling Options");
     var schedulingOptions = message.league.options.scheduling;
     if (!schedulingOptions) {
         winston.error("[SCHEDULING] {} league doesn't have scheduling options!?".format(message.league.options.name));
         deferred.resolve();
         return deferred.promise;
     } 
-    schedule_trace("6. Checking Spreadsheet Options");
     var spreadsheetOptions = message.league.options.spreadsheet;
     if (!spreadsheetOptions) {
         winston.error("[SCHEDULING] {} league doesn't have spreadsheet options!?".format(message.league.options.name));
         deferred.resolve();
         return deferred.promise;
     } 
-    schedule_trace("7. Checking if channel is in schedulingOptions: {} vs {}".format(channel.name, schedulingOptions.channel));
     if (!_.isEqual(channel.name, schedulingOptions.channel)) {
         deferred.resolve();
         return deferred.promise;
     }
-
-    schedule_trace("8. Ready to parse message");
 
     var isPotentialSchedule = false;
     var referencesSlackUsers = false;
@@ -589,7 +572,6 @@ function(bot, message) {
         results = spreadsheets.parseScheduling(message.text, schedulingOptions);
         isPotentialSchedule = true;
     } catch (e) {
-        schedule_trace("9. Caught Exception: " + e);
         if (!(e instanceof (spreadsheets.ScheduleParsingError))) {
             throw e; // let others bubble up
         } else {
@@ -598,13 +580,10 @@ function(bot, message) {
         }
     }
 
-    schedule_trace("10. Checking if it is a potential scheduling message");
     // Unless they included a date we can parse, ignore this message.
     if (!isPotentialSchedule) {
-        schedule_trace("11. nope");
         return;
     }
-    schedule_trace("13. Checking to see if valid named players");
     // Step 2. See if we have valid named players
     var white = users.getByNameOrID(results.white);
     var black = users.getByNameOrID(results.black);
@@ -614,7 +593,6 @@ function(bot, message) {
         referencesSlackUsers = true;
     }
 
-    schedule_trace("14. Attempting to update players");
     winston.debug("[SCHEDULING] Attempting to update the spreadsheet.");
     // Step 3. attempt to update the spreadsheet
     spreadsheets.updateSchedule(
@@ -622,7 +600,6 @@ function(bot, message) {
         schedulingOptions,
         results,
         function(err, reversed) {
-            schedule_trace("15. Spreadsheet callback invoked: {} / {}.".format(err, reversed));
             if (err) {
                 if (_.includes(err, "Unable to find pairing.")) {
                     hasPairing = false;
@@ -674,7 +651,6 @@ function(bot, message) {
             deferred.resolve();
         }
     );
-    schedule_trace("16. At end of scheduling callback, waiting for promises.");
     return deferred.promise;
 });
 
@@ -685,59 +661,41 @@ function(bot, message) {
 // results processing will occur on any message
 chesster.on({
     event: 'ambient',
-    middleware: [slack.withLeague]
+    middleware: [slack.withLeagueByChannelName]
 },
 function(bot, message) {
     var channel = channels.byId[message.channel];
-    var results_trace = _.noop;
-    if (channel) {
-        if (channel.name === "unstable_bot-lonewolf" || channel.name === "unstable_bot" || channel.name === "team-scheduling" || channel.name === "lonewolf-scheduling" || channel.name === "team-results" || channel.name === "team-gamelinks" || channel.name === "lonewolf-results" || channel.name === "lonewolf-gamelinks") {
-            results_trace = function(trace_message) {
-                winston.debug("[RESULTS][Message: {}]: {}".format(message.text, trace_message));
-            }
-        }
-    }
-    results_trace("1. Checking for League");
     if (!message.league) {
         return;
     }
-    results_trace("2. Checking for channel");
     if (!channel) {
         return;
     }
-    results_trace("3. Checking for spreadsheetOptions");
     var spreadsheetOptions = message.league.options.spreadsheet;
     if (!spreadsheetOptions) {
         winston.error("{} league doesn't have spreadsheet options!?".format(message.league.options.name));
         return;
     } 
-    results_trace("4. Checking for resultsOptions");
     var resultsOptions = message.league.options.results;
     if (!resultsOptions || !_.isEqual(channel.name, resultsOptions.channel)) {
         return;
     }
 
     try{
-        results_trace("5. Trying to parse result");
         var result = spreadsheets.parseResult(message.text);
  
-        results_trace("6. After parsing Result");
         if(!result.white || !result.black || !result.result){
-            results_trace("7. No good result");
             return;
         }
 
-        results_trace("8. Parsing usernames");
         result.white = users.getByNameOrID(result.white.replace(/[\<\@\>]/g, ''));
         result.black = users.getByNameOrID(result.black.replace(/[\<\@\>]/g, ''));
         
-        results_trace("9. checking that they are a moderator or one of the players");
         if(
             !_.isEqual(result.white.id, message.user) &&
             !_.isEqual(result.black.id, message.user) &&
             !message.player.isModerator()
         ){
-            results_trace("10. No permissions");
             replyPermissionFailure(bot, message);
             return;
         }
@@ -748,15 +706,12 @@ function(bot, message) {
         //I wrote before as simply as possibe for now
 
         //if a gamelink already exists, get it
-        results_trace("11. Find Game link");
         spreadsheets.fetchPairingGameLink(
             spreadsheetOptions,
             result,
             function(err, gamelink){
-                results_trace("12. Found Game Link: Err: {} / Gamelink: {}".format(err, gamelink));
                 //if a gamelink is found, use it to acquire details and process them
                 if(!err && gamelink){
-                    results_trace("13. processing game link");
                     processGamelink(
                         bot, 
                         message, 
@@ -764,19 +719,15 @@ function(bot, message) {
                         message.league.options.gamelinks, 
                         result); //user specified result
                 }else{
-                    results_trace("14. Updating with result only");
                     //update the spreadsheet with result only
                     spreadsheets.updateResult(
                         spreadsheetOptions,
                         result,
                         function(err, reversed, gamelinkChanged, resultChanged){
-                            results_trace("15. updateResults callback, err: {}".format(err));
                             if (err) {
                                 if (_.includes(err, "Unable to find pairing.")) {
-                                    results_trace("16. Missing Pairing");
                                     resultReplyMissingPairing(bot, message);
                                 } else {
-                                    results_trace("17. Something is wrong");
                                     bot.reply(message, "Something went wrong. Notify @endrawes0");
                                     throw new Error("Error updating scheduling sheet: " + err);
                                 }
@@ -784,7 +735,6 @@ function(bot, message) {
                                 if(resultChanged && !_.isEqual(result.result, SWORDS)){
                                     var white = result.white;
                                     var black = result.black;
-                                    results_trace("18. Game is over, notify people");
                                     var leagueName = message.league.options.name;
                                     subscription.emitter.emit('a-game-is-over',
                                         message.league,
@@ -793,7 +743,6 @@ function(bot, message) {
                                     });
                                 }
 
-                                results_trace("19. Result updated");
                                 resultReplyUpdated(bot, message, result);
                             }
                         }
@@ -803,8 +752,6 @@ function(bot, message) {
         );
 
     }catch(e){
-        results_trace("20. ERROR: {}".format(JSON.stringify(e)));
-        results_trace("21. STACK: {}".format(e.stack));
         //at the moment, we do not throw from inside the api - rethrow
         throw e;
     }
@@ -1045,45 +992,30 @@ function processGameDetails(bot, message, details, options){
 // gamelink processing will occur on any message
 chesster.on({
     event: 'ambient',
-    middleware: [slack.withLeague]
+    middleware: [slack.withLeagueByChannelName]
 },
 function(bot, message) {
     var channel = channels.byId[message.channel];
-    var gamelink_trace = _.noop;
-    if (channel) {
-        if (channel.name === "unstable_bot-lonewolf" || channel.name === "unstable_bot" || channel.name === "team-scheduling" || channel.name === "lonewolf-scheduling" || channel.name === "team-results" || channel.name === "team-gamelinks" || channel.name === "lonewolf-results" || channel.name === "lonewolf-gamelinks") {
-            gamelink_trace = function(trace_message) {
-                winston.debug("[GAMELINK][Message: {}]: {}".format(message.text, trace_message));
-            }
-        }
-    }
-    gamelink_trace("1. Detecting gamelink");
     if (!message.league) {
         return;
     }
-    gamelink_trace("2. checking for appropriate channel");
     if (!channel) {
         return;
     }
-    gamelink_trace("3. checking for spreadsheetOptions");
     var spreadsheetOptions = message.league.options.spreadsheet;
     if (!spreadsheetOptions) {
         winston.error("{} league doesn't have spreadsheet options!?".format(message.league.options.name));
         return;
     } 
-    gamelink_trace("4. checking for gamelinkOptions");
     var gamelinkOptions = message.league.options.gamelinks;
     if (!gamelinkOptions || !_.isEqual(channel.name, gamelinkOptions.channel)) {
         return;
     }
 
     try{
-        gamelink_trace("5. Processing Gamelink");
         processGamelink(bot, message, message.text, gamelinkOptions);
     }catch(e){
         //at the moment, we do not throw from inside the api - rethrow
-        gamelink_trace("6. ERROR: {}".format(JSON.stringify(e)));
-        gamelink_trace("7. STACK: {}".format(e.stack));
         throw e;
     }
 });


### PR DESCRIPTION
This should fix the issue we've been seeing. I don't have all of the messages that where failing, but the ones that were failing were due to chesster thinking that the message text was identifying the lone wolf league as a target.  In the single-purpose channels, we don't want that. posts in #team-scheduling should always be considered a 45+45 message, regardless of content. 

This achieves that. 