### PR TITLE
removed spewing to logs every time the ratings update

### DIFF
--- a/src/league.js
+++ b/src/league.js
@@ -151,10 +151,6 @@ var league_attributes = {
                         lichessRating.set('rating', player.rating);
                         lichessRating.set('lastCheckedAt', moment.utc().format());
                         lichessRating.save().then(function() {
-                            winston.info("Got updated rating from heltour for {name}: {rating}".format({
-                                name: player.username,
-                                rating: player.rating
-                            }));
                             unlock.resolve();
                         }).catch(function(error) {
                             winston.error("{}.refreshRosters.saveRating Error: {}".format(


### PR DESCRIPTION
I dont see a need for summary in its place - we already get the total for number of players and if there are errors they will be clear.