### PR TITLE
Add missing case-insensitivity to some commands

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -56,10 +56,10 @@ function appendPlayerRegex(command, optional) {
     if (optional) {
         // If the username is optional (as in the "rating" command), append
         // a ? to the whole player matching regex.
-        return new RegExp(playerRegex + "?");
+        return new RegExp(playerRegex + "?", "i");
     }
 
-    return new RegExp(playerRegex);
+    return new RegExp(playerRegex, "i");
 }
 
 function getSlackUser(message) {


### PR DESCRIPTION
No more chesster silence on "Pairing" command :tada:
Patterns matched by `chesster.hears(...)` are already case-insensitive per Slack API documentation (and practical tests).