### PR TITLE
Fix an issue with the database lock never being given up. 

### DIFF
--- a/src/chesster.js
+++ b/src/chesster.js
@@ -32,7 +32,7 @@ var adminSlack = new slack.Bot({
     slackName: "chesster",
     configFile: configFile,
     connectToModels: false,
-    refreshLeague: false,
+    refreshLeagues: false,
     logToThisSlack: true
 });
 

--- a/src/league.js
+++ b/src/league.js
@@ -183,6 +183,8 @@ var league_attributes = {
                         winston.error(JSON.stringify(err));
                         unlock.resolve();
                     });
+                }).catch(function(err) {
+                    winston.error(JSON.stringify(err));
                 });
             });
             self._playerLookup = newPlayerLookup;


### PR DESCRIPTION
This is likely the cause of the regular increase in memory usage. Although in this case, the memory usage can be reclaimed by the GC, so this isn't a memory leak.  The GC would happily reclaim this memory and be done with it. 