### PR TITLE
Fix message forwarding to private channels

### DIFF
--- a/src/commands/messageForwarding.js
+++ b/src/commands/messageForwarding.js
@@ -22,7 +22,7 @@ function forwardMessage(chesster, adminSlack) {
                 if (_.startsWith(t, '@')) {
                     users.push(chesster.users.getId(t.substr(1)));
                 } else if (_.startsWith(t, '#')) {
-                    channels.push(chesster.channels.getId(t.substr(1)));
+                    channels.push(t);
                 } else if (_.startsWith(t, '<@') && _.endsWith(t, '>')) {
                     var name = adminSlack.users.getByNameOrID(t.substr(2, t.length-3)).name;
                     users.push(chesster.users.getId(name));


### PR DESCRIPTION
This didn't work for private channels, since they aren't returned by the channels.list API method. The easiest fix is to remove the mapping from channel name to ID since it's not needed.