### PR TITLE
Fix refresh pairings command

### DIFF
--- a/src/commands/messageForwarding.js
+++ b/src/commands/messageForwarding.js
@@ -132,6 +132,7 @@ function refreshLeague(chesster, adminSlack) {
             if (type === "pairings") {
                 _league.refreshCurrentRoundSchedules().then(function(pairings) {
                     winston.info("Found " + pairings.length + " pairings for " + _league.options.name + " (manual refresh)");
+                    _league.emitter.emit('refreshPairings', _league);
                 }).catch(function(error) {
                     winston.error("{}: Error refreshing pairings: {}".format(_league.options.name, JSON.stringify(error)));
                 });

--- a/src/commands/scheduling.js
+++ b/src/commands/scheduling.js
@@ -483,7 +483,7 @@ function ambientScheduling(bot, message) {
             if (updateScheduleResults['error'] === 'not_found') {
                 schedulingReplyMissingPairing(bot, message);
                 deferred.resolve();
-            } else if (updateScheduleResults['error'] === 'no_data') {
+            } else if (updateScheduleResults['error'] === 'no_matching_rounds') {
                 replyNoActiveRound(bot, message);
                 deferred.resolve();
             } else if (updateScheduleResults['error'] === 'ambiguous') {


### PR DESCRIPTION
The refreshPairings event is needed for the command to work as intended and immediately update the watched players